### PR TITLE
Remove usage of xargo and switch to cargo build-std

### DIFF
--- a/applet/libapplet-launch/.cargo/config
+++ b/applet/libapplet-launch/.cargo/config
@@ -1,0 +1,2 @@
+[unstable]
+build-std = ["core", "compiler_builtins", "alloc"]

--- a/applet/libapplet-launch/Xargo.toml
+++ b/applet/libapplet-launch/Xargo.toml
@@ -1,1 +1,0 @@
-[dependencies.alloc]

--- a/applet/libapplet-launch/rust-toolchain
+++ b/applet/libapplet-launch/rust-toolchain
@@ -1,0 +1,1 @@
+nightly

--- a/fs-api/.cargo/config
+++ b/fs-api/.cargo/config
@@ -1,0 +1,2 @@
+[unstable]
+build-std = ["core", "compiler_builtins", "alloc"]

--- a/fs-api/Xargo.toml
+++ b/fs-api/Xargo.toml
@@ -1,1 +1,0 @@
-[dependencies.alloc]

--- a/fs-api/rust-toolchain
+++ b/fs-api/rust-toolchain
@@ -1,0 +1,1 @@
+nightly

--- a/graphics/gpu-simple/.cargo/config
+++ b/graphics/gpu-simple/.cargo/config
@@ -1,0 +1,2 @@
+[unstable]
+build-std = ["core", "compiler_builtins", "alloc"]

--- a/graphics/gpu-simple/Xargo.toml
+++ b/graphics/gpu-simple/Xargo.toml
@@ -1,1 +1,0 @@
-[dependencies.alloc]

--- a/graphics/gpu-simple/rust-toolchain
+++ b/graphics/gpu-simple/rust-toolchain
@@ -1,0 +1,1 @@
+nightly

--- a/graphics/simple-window/.cargo/config
+++ b/graphics/simple-window/.cargo/config
@@ -1,0 +1,2 @@
+[unstable]
+build-std = ["core", "compiler_builtins", "alloc"]

--- a/graphics/simple-window/Xargo.toml
+++ b/graphics/simple-window/Xargo.toml
@@ -1,1 +1,0 @@
-[dependencies.alloc]

--- a/graphics/simple-window/rust-toolchain
+++ b/graphics/simple-window/rust-toolchain
@@ -1,0 +1,1 @@
+nightly

--- a/server-ipc/simple-mitm-service/client/.cargo/config
+++ b/server-ipc/simple-mitm-service/client/.cargo/config
@@ -1,0 +1,2 @@
+[unstable]
+build-std = ["core", "compiler_builtins", "alloc"]

--- a/server-ipc/simple-mitm-service/client/Xargo.toml
+++ b/server-ipc/simple-mitm-service/client/Xargo.toml
@@ -1,1 +1,0 @@
-[dependencies.alloc]

--- a/server-ipc/simple-mitm-service/client/rust-toolchain
+++ b/server-ipc/simple-mitm-service/client/rust-toolchain
@@ -1,0 +1,1 @@
+nightly

--- a/server-ipc/simple-mitm-service/server/.cargo/config
+++ b/server-ipc/simple-mitm-service/server/.cargo/config
@@ -1,0 +1,2 @@
+[unstable]
+build-std = ["core", "compiler_builtins", "alloc"]

--- a/server-ipc/simple-mitm-service/server/Xargo.toml
+++ b/server-ipc/simple-mitm-service/server/Xargo.toml
@@ -1,1 +1,0 @@
-[dependencies.alloc]

--- a/server-ipc/simple-mitm-service/server/rust-toolchain
+++ b/server-ipc/simple-mitm-service/server/rust-toolchain
@@ -1,0 +1,1 @@
+nightly


### PR DESCRIPTION
This should simplify quite some stuffs while building.